### PR TITLE
add SessionTime

### DIFF
--- a/Sources/SuitEtecsaSdk/entity/SessionTime.swift
+++ b/Sources/SuitEtecsaSdk/entity/SessionTime.swift
@@ -1,0 +1,18 @@
+public struct SessionTime {
+  public let value: String
+
+  public var errorop: Bool {
+    return value == "errorop"
+  }
+
+  public var asSeconds: Int? {
+    let components = value.split(separator: ":").compactMap { Int($0) }
+    return components.count == 3 ? components[0] * 3600 + components[1] * 60 + components[2] : nil
+  }
+
+  public var asMillis: Int? {
+    let components = value.split(separator: ":").compactMap { Int($0) }
+    return components.count == 3
+      ? ((components[0] * 3600 + components[1] * 60 + components[2]) * 1000) : nil
+  }
+}

--- a/Sources/SuitEtecsaSdk/extensions/entity/nauta/auth/LoginResponse+.swift
+++ b/Sources/SuitEtecsaSdk/extensions/entity/nauta/auth/LoginResponse+.swift
@@ -1,0 +1,5 @@
+extension LoginResponse {
+  var ok: Bool {
+    self.result == "ok"
+  }
+}

--- a/Sources/SuitEtecsaSdk/remote/apis/ConnectApi.swift
+++ b/Sources/SuitEtecsaSdk/remote/apis/ConnectApi.swift
@@ -95,7 +95,7 @@ public class ConnectApi {
     return Result.success(userDetails)
   }
 
-  public static func getLeftTime(_ dataSession: DataSession) async -> Result<String, NautaException>
+  public static func getLeftTime(_ dataSession: DataSession) async -> Result<SessionTime, NautaException>
   {
     let parameters = [
       "op": "getLeftTime",
@@ -118,7 +118,7 @@ public class ConnectApi {
       return Result.failure(
         NautaException.failFetchInformation(message: "Fail to obtain remaining time!"))
     }
-    return Result.success(remainingTime)
+    return Result.success(SessionTime(value: remainingTime))
   }
 
   public static func disconnect(_ dataSession: DataSession) async -> Result<Void, NautaException> {


### PR DESCRIPTION
Ahora ConnectApi.getLeftTime devuelve un objeto `SessionTime`, el atributo `value` contiene el String devuelto por el portal, `errorop` devuelve true si el texto es "errorop", en caso contrario, `asSeconds` devuelve el tiempo en segundos y `asMillis` en milisegundos